### PR TITLE
Users with no Beers in their selection cause warnings/issues with BeerList rendering.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 build
+.chrome
+.vscode

--- a/src/app/BeerList.js
+++ b/src/app/BeerList.js
@@ -94,7 +94,9 @@ class BeerList extends Component {
             );
         });
 
-        const userBeerList = userBeers.map((userBeer) => (
+        const userBeerList = userBeers
+            .filter(userBeer => userBeer.BeerSelection.BeerId > 0)
+            .map((userBeer) => (
             <tr key={userBeer.BeerSelection.BeerId}>
                 <td>
                     <img src= {userBeer.BeerSelection.Label} style={styles.img}/>


### PR DESCRIPTION
Because all users come down with empty beerselection and beers yet the ids are 0. This causes duplicate child key warnings as well as exceptions when trying to render out the Brewery Name if no beer or brewery is avail.