### PR TITLE
Added config.json for api url. ALso made a few adjustments/enhancements to the typeahead for beer lookups.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+    "ApiBaseUrl": "http://beerswap.dev.enservio.lan/BeerWS/api/"
+}

--- a/src/app/AllBeerList.js
+++ b/src/app/AllBeerList.js
@@ -5,6 +5,8 @@ import List from 'material-ui/List';
 import ListItem from 'material-ui/List/ListItem';
 import Avatar from 'material-ui/Avatar';
 
+var AppConfig = require('AppConfig');
+
 const styles = {
     container: {
         textAlign: 'center',
@@ -40,7 +42,7 @@ class AllBeerList extends Component {
 
     componentWillMount() {
         // get the beers for this swap
-        let url = `http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/List/V1/`,
+        let url = AppConfig.ApiBaseUrl + `Beer/Swap/List/V1/`,
             me = this;
 
         fetch(url, {

--- a/src/app/BeerList.js
+++ b/src/app/BeerList.js
@@ -7,6 +7,8 @@ import Subheader from 'material-ui/Subheader';
 import Avatar from 'material-ui/Avatar';
 import {muiTheme} from './ColorScheme';
 
+var AppConfig = require('AppConfig');
+
 const styles = {
     container: {
         textAlign: 'center',
@@ -50,7 +52,7 @@ class BeerList extends Component {
         // get the beers for this swap
         let swapId = this.state.swapId,
             // url = `http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/List/V1/${swapId}`,
-            url = `http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/attendees/V1/${swapId}`,
+            url = AppConfig.ApiBaseUrl + `Beer/Swap/attendees/V1/${swapId}`,
             me = this;
 
         fetch(url, {

--- a/src/app/CreateSwap.js
+++ b/src/app/CreateSwap.js
@@ -5,6 +5,8 @@ import TimePicker from 'material-ui/TimePicker';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import {muiTheme} from './ColorScheme';
 
+var AppConfig = require('AppConfig');
+
 const styles = {
     container: {
         textAlign: 'center',
@@ -40,7 +42,7 @@ class CreateSwap extends Component {
             alert('No swap Date!');
         }
 
-        fetch('http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/V1', {
+        fetch(AppConfig.ApiBaseUrl + 'Beer/Swap/V1', {
             headers: new Headers({
                 'Content-Type': 'application/json'
             }),

--- a/src/app/InviteUsers.js
+++ b/src/app/InviteUsers.js
@@ -6,6 +6,8 @@ import RaisedButton from 'material-ui/RaisedButton';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import {muiTheme} from './ColorScheme';
 
+var AppConfig = require('AppConfig');
+
 const styles = {
     container: {
 
@@ -41,7 +43,7 @@ class InviteUsers extends Component {
 
     componentWillMount() {
         let me = this;
-        fetch('http://beerswap.enservio.lan/BeerWS/api/User/V1').then(function (response) {
+        fetch(AppConfig.ApiBaseUrl + 'User/V1').then(function (response) {
             return response.json();
         }).then(setUsers);
 
@@ -88,7 +90,7 @@ class InviteUsers extends Component {
         }
 
         let swapId = this.state.swapId;
-        let url = 'http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/Invite/V1/' + swapId;
+        let url = AppConfig.ApiBaseUrl + 'Beer/Swap/Invite/V1/' + swapId;
         fetch(url, {
             headers: new Headers({
                 'Content-Type': 'application/json'

--- a/src/app/JoinSwap.js
+++ b/src/app/JoinSwap.js
@@ -9,6 +9,8 @@ import {GridList, GridTile} from 'material-ui/GridList';
 import IconButton from 'material-ui/IconButton';
 import StarBorder from 'material-ui/svg-icons/toggle/star-border';
 
+var AppConfig = require('AppConfig');
+
 const styles = {
     container: {
         textAlign: 'center',
@@ -44,7 +46,7 @@ class JoinSwap extends Component {
         // Associate this user with this beer swap
         let swapId = this.state.swapId,
             userId = this.state.userId,
-            joinUrl = `http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/Join/V1/${swapId}/${userId}`,
+            joinUrl = AppConfig.ApiBaseUrl + `Beer/Swap/Join/V1/${swapId}/${userId}`,
             me = this;
 
         fetch(joinUrl, {
@@ -63,10 +65,10 @@ class JoinSwap extends Component {
     }
 
     handleBeerInput(txtValue, datasource) {
-        if (txtValue.indexOf(' ') > -1) {
+        if (txtValue.lastIndexOf(' ') == txtValue.length - 1) {
             let words = txtValue.split(' ');
-            if (words.length !== 0 && this.state.searchTerm !== words[0]) {
-                let url = `http://beerswap.enservio.lan/BeerWS/api/Beer/search/V1/${words[0]}`;
+            if (words.length !== 0 && this.state.searchTerm !== words) {
+                let url = AppConfig.ApiBaseUrl + `Beer/search/V1/${words}`;
                 let me = this;
                 this.setState({
                     searchTerm: words[0]
@@ -103,7 +105,7 @@ class JoinSwap extends Component {
             swapId = this.state.swapId,
             beerId = this.state.beerId;
 
-        let url = `http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/User/Beer/V1/${swapId}/${userId}/${beerId}`;
+        let url = AppConfig.ApiBaseUrl + `Beer/Swap/User/Beer/V1/${swapId}/${userId}/${beerId}`;
         fetch(url, {
             headers: new Headers({
                 'Content-Type': 'application/json'
@@ -192,7 +194,7 @@ class BeerGridList extends Component {
         // Get the beers associated with this beer swap
         let me = this,
             swapId = this.state.swapId,
-            getBeersUrl = `http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/List/V1/${swapId}`;
+            getBeersUrl = AppConfig.ApiBaseUrl + `Beer/Swap/List/V1/${swapId}`;
         fetch(getBeersUrl, {
             headers: new Headers({
                 'Content-Type': 'application/json'

--- a/src/app/SwapCreated.js
+++ b/src/app/SwapCreated.js
@@ -4,6 +4,8 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import {muiTheme} from './ColorScheme';
 import RaisedButton from 'material-ui/RaisedButton';
 
+var AppConfig = require('AppConfig');
+
 const styles = {
     container: {
         textAlign: 'center',
@@ -55,7 +57,7 @@ class SwapCreated extends Component {
         this.setState({reminderSent: true});
         let me = this;
         let swapId = this.state.swapId;
-        let url = 'http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/Remind/V1/' + swapId;
+        let url = AppConfig.ApiBaseUrl + 'Beer/Swap/Remind/V1/' + swapId;
         fetch(url, {
             headers: new Headers({
                 'Content-Type': 'application/json'
@@ -80,7 +82,7 @@ class SwapCreated extends Component {
     handleFinalizeSwap = () => {
         let me = this;
         let swapId = this.state.swapId;
-        let url = 'http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/attendees/randomize/V1/' + swapId;
+        let url = AppConfig.ApiBaseUrl + 'Beer/Swap/attendees/randomize/V1/' + swapId;
         fetch(url, {
             headers: new Headers({
                 'Content-Type': 'application/json'

--- a/src/app/actions/RunSwapActions.js
+++ b/src/app/actions/RunSwapActions.js
@@ -1,3 +1,5 @@
+var AppConfig = require('AppConfig');
+
 export function setSwapId(swapId) {
     return {
         type: 'SET_SWAP',
@@ -13,7 +15,7 @@ export function fetchSwap(swapId) {
 
         // In this case, we return a promise to wait for.
         // This is not required by thunk middleware, but it is convenient for us.
-        let url = `http://beerswap.enservio.lan/BeerWS/api/Beer/Swap/attendees/V1/${swapId}`;
+        let url = AppConfig.ApiBaseUrl + `Beer/Swap/attendees/V1/${swapId}`;
 
         return fetch(url, {
                 headers: new Headers({
@@ -47,7 +49,7 @@ export function selectBeer(swapId, userId, beerId) {
 
         // In this case, we return a promise to wait for.
         // This is not required by thunk middleware, but it is convenient for us.
-        let url = `http://beerswap.enservio.lan/BeerWS/api/User/Swap/Selection/V1/${swapId}/${userId}/${beerId}`;
+        let url = AppConfig.ApiBaseUrl + `User/Swap/Selection/V1/${swapId}/${userId}/${beerId}`;
 
         return fetch(url, {
             headers: new Headers({

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -44,6 +44,9 @@ const config = {
       },
     ],
   },
+  externals: {
+    'AppConfig': JSON.stringify(require('./config.json'))
+  }
 };
 
 module.exports = config;

--- a/webpack-production.config.js
+++ b/webpack-production.config.js
@@ -43,6 +43,9 @@ const config = {
       },
     ],
   },
+  externals: {
+    'AppConfig': JSON.stringify(require('./config.json'))
+  }
 };
 
 module.exports = config;


### PR DESCRIPTION
I added a config.json to store the api url for now. I also made an adjustment to the typeahead logic in JoinSwap to perform a lookup on all words typed when the user presses space so that, for example, if someone types green <space> monster it will actually narrow the search down. The problem with the original method was that it only relied on the first word and the beer api limits the results to just 50 so often times the users would not see the beer they want.